### PR TITLE
Update: `actions/checkout@v6`

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🛠️ Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Zenodo Metadata
         uses: ./

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🛡️ Validate Zenodo Metadata
         uses: vsoch/zenodo-validator@main 


### PR DESCRIPTION
Avoid that users copy an outdated version from the README. Update our own CI.